### PR TITLE
Games only start at designated times.

### DIFF
--- a/Server/painttheworld/app.py
+++ b/Server/painttheworld/app.py
@@ -52,8 +52,6 @@ class GameData(Resource):
         resp = {}
         if out_of_bounds:
             resp['out-of-bounds'] = True
-        # return_deltas = [[(1, 2), constants.Team.RED]]
-        print(return_deltas)
         resp['grid-deltas'] = [{'coord': {'x': 1, 'y': 2}, 'color': 1}]
 
 

--- a/Server/painttheworld/app.py
+++ b/Server/painttheworld/app.py
@@ -52,8 +52,8 @@ class GameData(Resource):
         resp = {}
         if out_of_bounds:
             resp['out-of-bounds'] = True
-        return_deltas = [[(1, 2), constants.Team.RED]]
-        
+        # return_deltas = [[(1, 2), constants.Team.RED]]
+        print(return_deltas)
         resp['grid-deltas'] = [{'coord': {'x': 1, 'y': 2}, 'color': 1}]
 
 

--- a/Server/painttheworld/app.py
+++ b/Server/painttheworld/app.py
@@ -42,9 +42,13 @@ class GameData(Resource):
         elif not validate_coordinates((args['long'], args['lat'])):
             return {'error': 'Invalid coordinates.'}, 400
         
-        return_deltas, out_of_bounds = active_game.update_user(args['user-id'],
-                                             args['long'],
-                                             args['lat'])
+        try:
+            return_deltas, out_of_bounds = active_game.update_user(args['user-id'],
+                                                 args['long'],
+                                                 args['lat'])
+        except RuntimeError as e:
+            return {'error': e.args}, 400
+
         resp = {}
         if out_of_bounds:
             resp['out-of-bounds'] = True

--- a/Server/painttheworld/game.py
+++ b/Server/painttheworld/game.py
@@ -50,7 +50,8 @@ class GameState:
         """
         self.center_coord = np.mean(self.user_coords, axis=1)
         self.conversion_rates = self.conversion_rates(self.center_coord)
-        self.start_time = (datetime.datetime.now() + datetime.timedelta(seconds=3))
+        self.start_time = datetime.datetime.now() + datetime.timedelta(seconds=3)
+        self.end_time = self.start_time + datetime.timedelta(minutes=3)
 
     def update(self, coord, team):
         """Update the game state array."""
@@ -128,15 +129,22 @@ class GameState:
             return -1
 
     def update_user(self, id, lon, lat):
-        gridloc = self.project(lon, lat)
-        out_of_bounds = self.check_grid_range(gridloc)
-        
-        if not out_of_bounds:
-            self.grid[gridloc] = constants.Team.findTeam(id)
+        currtime = datetime.datetime.now()
+        if self.start_time < currtime < self.end_time: 
+            gridloc = self.project(lon, lat)
+            out_of_bounds = self.check_grid_range(gridloc)
+            
+            if not out_of_bounds:
+                self.grid[gridloc] = constants.Team.findTeam(id)
 
-        returngrid =  self.diff(self.user_grid[id], self.grid)
-        self.user_grid[id] = self.grid
-        return returngrid, out_of_bounds
+            returngrid =  self.diff(self.user_grid[id], self.grid)
+            self.user_grid[id] = self.grid
+            return returngrid, out_of_bounds
+        else:
+            if self.start_time > currtime:
+                raise RuntimeError('Game hasn\'t started.')
+            else:
+                raise RuntimeError('Game over.')
 
     def check_grid_range(self, coord):
         return coord[0] >= 0 and coord[1] >=0 and coord[0] < constants.radius*2+1 and coord[1] < constants.radius*2+1

--- a/Server/painttheworld/game.py
+++ b/Server/painttheworld/game.py
@@ -132,7 +132,10 @@ class GameState:
         currtime = datetime.datetime.now()
         if self.start_time < currtime < self.end_time: 
             gridloc = self.project(lon, lat)
-            out_of_bounds = self.check_grid_range(gridloc)
+            print(gridloc[0])
+            print(gridloc[1])
+            print(constants.radius*2+1)
+            out_of_bounds = not self.check_grid_range(gridloc)
             
             if not out_of_bounds:
                 self.grid[gridloc] = constants.Team.findTeam(id)

--- a/Server/painttheworld/game.py
+++ b/Server/painttheworld/game.py
@@ -132,9 +132,6 @@ class GameState:
         currtime = datetime.datetime.now()
         if self.start_time < currtime < self.end_time: 
             gridloc = self.project(lon, lat)
-            print(gridloc[0])
-            print(gridloc[1])
-            print(constants.radius*2+1)
             out_of_bounds = not self.check_grid_range(gridloc)
             
             if not out_of_bounds:


### PR DESCRIPTION
Games now are hardcoded to last for three minutes.
Otherwise, the endpoint will return an error.